### PR TITLE
Handle null contexts

### DIFF
--- a/lib/composable-middleware.js
+++ b/lib/composable-middleware.js
@@ -14,6 +14,7 @@ var MiddlewareCommonObject= require('./middleware-common-object')
 function is_protected_context(obj)
 {
   return obj === undefined ||
+    obj === null ||
     obj === global ||
     (obj._middleware_common_object === undefined && obj.route !== undefined && obj.handle !== undefined)
 }

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "composable-middleware",
+  "name": "@ineentho/composable-middleware",
   "description": "Treat a sequence of middleware as middleware.",
   "version": "0.3.0",
-  "homepage": "https://github.com/randymized/composable-middleware",
+  "homepage": "https://github.com/ineentho/composable-middleware",
   "author": {
     "name": "Randy McLaughlin",
     "email": "ot40ddj02@sneakemail.com"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/randymized/composable-middleware.git"
+    "url": "git://github.com/ineentho/composable-middleware.git"
   },
   "bugs": {
-    "url": "https://github.com/randymized/composable-middleware/issues"
+    "url": "https://github.com/ineentho/composable-middleware/issues"
   },
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/randymized/composable-middleware/blob/master/LICENSE-MIT"
+      "url": "https://github.com/ineentho/composable-middleware/blob/master/LICENSE-MIT"
     }
   ],
   "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ineentho/composable-middleware",
   "description": "Treat a sequence of middleware as middleware.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage": "https://github.com/ineentho/composable-middleware",
   "author": {
     "name": "Randy McLaughlin",


### PR DESCRIPTION
Some modules, for example express-promise-router, could give the middleware a null context.